### PR TITLE
Fix Node 6 warning

### DIFF
--- a/src/azVmManagerTask/task.json
+++ b/src/azVmManagerTask/task.json
@@ -85,6 +85,9 @@
     "execution": {
         "Node": {
             "target": "azurevmmanager.js"
+        },
+        "Node20_1": {
+            "target": "azurevmmanager.js"
         }
     }
 }


### PR DESCRIPTION
With the recent default environments, using the task produces the following warning:

```
Task 'Azure Virtual Machine Manager' version 1 (AzureVirtualMachineManagerTask@1) is dependent on a Node version (6) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance
```

This PR confirms that it runs with the current (20) Node version. I have tested it an the task runs fine with this change and the warning is gone.